### PR TITLE
Fix: Correctly display team names in match list

### DIFF
--- a/volleyball_replay_v1.html
+++ b/volleyball_replay_v1.html
@@ -310,7 +310,7 @@
             const fragment = document.createDocumentFragment();
 
             matches.forEach(match => {
-                const { match_id, date, home_team_name, away_team_name, status } = match;
+                const { match_id, date, status } = match;
                 const matchItemDiv = document.createElement('div');
                 matchItemDiv.className = 'p-3 mb-2 border rounded-md bg-white shadow-sm';
 
@@ -322,7 +322,7 @@
 
                 const teamsEl = document.createElement('h4');
                 teamsEl.className = 'font-semibold text-gray-800';
-                teamsEl.textContent = `${home_team_name} vs ${away_team_name}`;
+                teamsEl.textContent = `${match.team_A_name || 'Home Team'} vs ${match.team_B_name || 'Away Team'}`;
                 
                 const statusEl = document.createElement('p');
                 statusEl.className = 'text-sm';


### PR DESCRIPTION
The API response for team matches uses 'team_A_name' and 'team_B_name' for the team names. I updated the `displayMatchList` function to use these properties.

I also removed a temporary console.log statement used for diagnosing the property names.